### PR TITLE
added mrt:moment dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -12,6 +12,7 @@ Package.onUse(function(api) {
   api.use('accounts-base', ['client', 'server']);
   api.imply('accounts-base', ['client', 'server']);
   api.use('accounts-oauth', ['client', 'server']);
+  api.use('mrt:moment', ['client', 'server']);
   
   api.use('selaias:runkeeper@0.6.0', ['client', 'server']);
 


### PR DESCRIPTION
Added mrt:moment dependency. It was missing before.

Without moment, the following error is seen on login:
`Error in OAuth Server: moment is not defined
Exception while invoking method 'login' ReferenceError: moment is not
defined
at Object.userAgent [as handleOauthRequest]
(packages/selaias:runkeeper/runkeeper_server.js:17:1)
at OAuth._requestHandlers.(anonymous function)
(packages/oauth2/oauth2_server.js:8:1)
at middleware (packages/oauth/oauth_server.js:173:1)
at packages/oauth/oauth_server.js:146:1`
